### PR TITLE
Reduce websocket load and rerenders

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -33,10 +33,6 @@ function broadcastGuessWord(gameId, guess, playerId) {
   io.to(gameId).emit("guess word", { guess, playerId });
 }
 
-function broadcastDrawOperation(gameId, drawOperation) {
-  io.to(gameId).emit("draw operation", drawOperation);
-}
-
 function listenSocket(server) {
   io = SocketIO(server);
   io.on("connection", (socket) => {
@@ -83,7 +79,7 @@ function listenSocket(server) {
 
       socket.on("draw operation", ({ gameId, ...drawOperation }) => {
         addDrawOperation(gameId, { ...drawOperation, playerId });
-        broadcastDrawOperation(gameId, drawOperation);
+        socket.to(gameId).emit("draw operation", drawOperation);
       });
 
       socket.on("clear canvas", (gameId) => {

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState, useCallback } from "react";
 import styled from "@emotion/styled";
 import Button from "./Button";
 
@@ -55,7 +55,6 @@ function Canvas({
     if (!drawing || disabled || !previous || !current) {
       return;
     }
-
     const ctx = canvasRef.current.getContext("2d");
     ctx.beginPath();
     ctx.moveTo(previous[0], previous[1]);
@@ -67,14 +66,7 @@ function Canvas({
     onChange({ previous, current, color });
   }, [onChange, drawing, previous, current, color, disabled]);
 
-  useEffect(() => {
-    if (!drawOperation) {
-      return;
-    }
-    paint(drawOperation);
-  }, [drawOperation]);
-
-  function paint(drawOperation) {
+  const paint = useCallback((drawOperation) => {
     const ctx = canvasRef.current.getContext("2d");
 
     ctx.beginPath();
@@ -84,45 +76,64 @@ function Canvas({
     ctx.lineWidth = 2;
     ctx.stroke();
     ctx.closePath();
-  }
+  }, []);
 
-  function handleMouseDown(event) {
+  useEffect(() => {
+    if (!drawOperation) {
+      return;
+    }
+    paint(drawOperation);
+  }, [drawOperation, paint]);
+
+  const handleMouseDown = useCallback((event) => {
     setCurrent(calcDrawPosition(event, canvasRef.current));
     setDrawing(true);
-  }
+  }, []);
 
-  function handleMouseUp() {
+  const handleMouseUp = useCallback(() => {
     setDrawing(false);
     setCurrent(null);
     setPrevious(null);
-  }
+  }, []);
 
-  function handleMouseMove(event) {
-    setPrevious(current);
-    setCurrent(calcDrawPosition(event, canvasRef.current));
-  }
+  const handleMouseMove = useCallback(
+    (event) => {
+      setPrevious(current);
+      setCurrent(calcDrawPosition(event, canvasRef.current));
+    },
+    [current]
+  );
 
-  function handleTouchStart(event) {
-    const touch = event.touches[0];
-    const mouseEvent = new MouseEvent("mousedown", {
-      clientX: touch.clientX,
-      clientY: touch.clientY,
-    });
-    handleMouseDown(mouseEvent);
-  }
+  const handleTouchStart = useCallback(
+    (event) => {
+      const touch = event.touches[0];
+      const mouseEvent = new MouseEvent("mousedown", {
+        clientX: touch.clientX,
+        clientY: touch.clientY,
+      });
+      handleMouseDown(mouseEvent);
+    },
+    [handleMouseDown]
+  );
 
-  function handleTouchEnd(event) {
-    handleMouseUp();
-  }
+  const handleTouchEnd = useCallback(
+    (event) => {
+      handleMouseUp();
+    },
+    [handleMouseUp]
+  );
 
-  function handleTouchMove(event) {
-    const touch = event.touches[0];
-    const mouseEvent = new MouseEvent("mousemove", {
-      clientX: touch.clientX,
-      clientY: touch.clientY,
-    });
-    handleMouseMove(mouseEvent);
-  }
+  const handleTouchMove = useCallback(
+    (event) => {
+      const touch = event.touches[0];
+      const mouseEvent = new MouseEvent("mousemove", {
+        clientX: touch.clientX,
+        clientY: touch.clientY,
+      });
+      handleMouseMove(mouseEvent);
+    },
+    [handleMouseMove]
+  );
 
   return (
     <>

--- a/src/pages/Game.js
+++ b/src/pages/Game.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useState, useRef, useCallback } from "react";
 import Canvas from "../components/Canvas";
 import SocketIO from "socket.io-client";
 import { useParams } from "react-router-dom";
@@ -69,30 +69,36 @@ const Game = () => {
     };
   }, [playerName, gameId]);
 
+  const handleCanvasChange = useCallback(
+    (drawOperation) => {
+      socketRef.current.emit("draw operation", {
+        ...drawOperation,
+        gameId,
+      });
+    },
+    [gameId]
+  );
+
+  const handleStartGameClick = useCallback(() => {
+    socketRef.current.emit("start game", gameId);
+  }, [gameId]);
+
+  const handleGuessSubmit = useCallback(
+    (guess) => {
+      socketRef.current.emit("guess word", {
+        guess,
+        gameId,
+      });
+    },
+    [gameId]
+  );
+
+  const handleClear = useCallback(() => {
+    socketRef.current.emit("clear canvas", gameId);
+  }, [gameId]);
+
   if (!playerName) {
     return <SelectPlayerName />;
-  }
-
-  function handleCanvasChange(drawOperation) {
-    socketRef.current.emit("draw operation", {
-      ...drawOperation,
-      gameId,
-    });
-  }
-
-  function handleStartGameClick() {
-    socketRef.current.emit("start game", gameId);
-  }
-
-  function handleGuessSubmit(guess) {
-    socketRef.current.emit("guess word", {
-      guess,
-      gameId,
-    });
-  }
-
-  function handleClear() {
-    socketRef.current.emit("clear canvas", gameId);
   }
 
   if (!game) {


### PR DESCRIPTION
The drawing position was sent too often even if the mouse didn't move.
This is fixed by using memorized callbacks:
https://reactjs.org/docs/hooks-reference.html#usecallback

The drawing position is only sent to other clients now.